### PR TITLE
Generalized line unfolding in parser (issue #8)

### DIFF
--- a/src/vobject/lib.rs
+++ b/src/vobject/lib.rs
@@ -156,6 +156,7 @@ impl<'s> Parser<'s> {
         }
     }
 
+    #[inline]
     fn peek(&self) -> Option<(char, usize)> {
         self.peek_at(0)
     }
@@ -178,7 +179,7 @@ impl<'s> Parser<'s> {
     }
 
     fn consume_char(&mut self) -> Option<char> {
-        match self.peek_at(0) {
+        match self.peek() {
             Some((c, offset)) => { self.pos += offset; Some(c) },
             None => None
         }
@@ -187,7 +188,7 @@ impl<'s> Parser<'s> {
     /// If next peeked char is the given `c`, consume it and return `true`,
     /// otherwise return `false`.
     fn consume_only_char(&mut self, c: char) -> bool {
-        match self.peek_at(0) {
+        match self.peek() {
             Some((d, offset)) if d == c => {self.pos += offset; true},
             _ => false
         }

--- a/src/vobject/lib.rs
+++ b/src/vobject/lib.rs
@@ -231,7 +231,7 @@ impl<'s> Parser<'s> {
     // implementation detail : instead of pushing char after char, we
     // do it by the biggest contiguous slices possible, because I believe it
     // to be more efficient (less checks for reallocation etc).
-    fn consume_while<'a, F: Fn(char) -> bool>(&'a mut self, test: F) -> String {
+    fn consume_while<F: Fn(char) -> bool>(&mut self, test: F) -> String {
         let mut sl_start_pos = self.pos;
         let mut res = String::new();
         while !self.eof() {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -112,6 +112,7 @@ fn test_icalendar_multline2() {
         END:VEVENT\n\
         END:VCALENDAR\n").unwrap();
 
+    assert_eq!(event.name, s!("VCALENDAR"));
 }
 
 #[test]


### PR DESCRIPTION
Ignoring (CR)LF followed by a single whitespace char is now done in peek()
and therefore is enforced in all processing.

This version has been able to parse a full ics file exported from Google (the very one with which I encountered issue #8).
This is work in progress, and my actual first non utterly trivial code in Rust, don't hesitate to say if the approach taken doesn't suit you, or if assumptions about efficiency are wrong etc.

Some choices:

- in `consume_while()`, tried to minimize the copying operations, but it can't return a str (slice) 
  anymore in any case.
- for simplicity, I discarded CR completely from peek_at(). If you agree with this, some conditions 
  downstream (consume_eol()...) can be simplified.
