### PR TITLE
Switch to BTreeMap

### DIFF
--- a/src/component.rs
+++ b/src/component.rs
@@ -1,5 +1,5 @@
 use std::str::FromStr;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use property::Property;
 use parser::Parser;
@@ -11,7 +11,7 @@ pub struct Component {
     pub name: String,
 
     /// The component's properties.
-    pub props: HashMap<String, Vec<Property>>,
+    pub props: BTreeMap<String, Vec<Property>>,
 
     /// The component's child- or sub-components.
     pub subcomponents: Vec<Component>
@@ -21,7 +21,7 @@ impl Component {
     pub fn new<N: Into<String>>(name: N) -> Component {
         Component {
             name: name.into(),
-            props: HashMap::new(),
+            props: BTreeMap::new(),
             subcomponents: vec![]
         }
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use component::Component;
 use property::Property;
@@ -250,8 +250,8 @@ impl<'s> Parser<'s> {
         Ok((name, value))
     }
 
-    fn consume_params(&mut self) -> HashMap<String, String> {
-        let mut rv: HashMap<String, String> = HashMap::new();
+    fn consume_params(&mut self) -> BTreeMap<String, String> {
+        let mut rv: BTreeMap<String, String> = BTreeMap::new();
         while self.consume_only_char(';') {
             match self.consume_param() {
                 Ok((name, value)) => { rv.insert(name.to_owned(), value.to_owned()); },

--- a/src/property.rs
+++ b/src/property.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 #[derive(Clone, Debug)]
 pub struct Property {
@@ -6,7 +6,7 @@ pub struct Property {
     pub name: String,
 
     /// Parameters.
-    pub params: HashMap<String, String>,
+    pub params: BTreeMap<String, String>,
 
     /// Value as unparsed string.
     pub raw_value: String,
@@ -24,7 +24,7 @@ impl Property {
     {
         Property {
             name: name.into(),
-            params: HashMap::new(),
+            params: BTreeMap::new(),
             raw_value: escape_chars(value.as_ref()),
             prop_group: None
         }


### PR DESCRIPTION
Due to the refactorings from #15 which started before the change to `BTreeMap` internally, I did accidentially end up with `HashMap` as map type.

This PR fixes this up.

Ref #14 