### PR TITLE
Let Vcard derive Debug

### DIFF
--- a/src/vcard.rs
+++ b/src/vcard.rs
@@ -8,6 +8,7 @@ use property::Property;
 use std::result::Result as RResult;
 use error::*;
 
+#[derive(Debug)]
 pub struct Vcard(Component);
 
 /// The Vcard object.


### PR DESCRIPTION
Here it comes.

The `Vcard` type was not `Debug` before, but I guess that'd be a nice idea.

After this is merged, we can discuss releasing.

I want to include a builder for `Icalendar` objects, so one can build calendars from Rust, but I think there's no rush on including this. If you feel comfortable releasing, feel free!

---

As you might now, I need the whole high-level interface for my work on [imag](https://github.com/matthiasbeyer/imag) components for calendar and contacts,... but as I'm only making slow progress, the high-level calendar interface (especially the "calendar-building"-part) will quite take some time. Even the usage of the high-level icalendar interface will take some time, as I've not yet gotten into writing a calendar component for imag. So I don't need the high-level Icalendar interface _right now_, but some time in the future. So if you're okay with waiting for more functionality in this part of the crate, I wouldn't argue against waiting with a new release.

But on the other hand, I have no arguments against releasing a new version... so feel free to, if you're comfortable with the codebase as is. :smile: 

---

Either way: A big thank you for letting me develop all these patches and integrating them! :heart: 