### PR TITLE
Add params getter for helper datatype generator

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -43,6 +43,10 @@ macro_rules! create_data_type {
             pub fn into_raw(self) -> String {
                 self.0
             }
+
+            pub fn params(&self) -> &$crate::param::Parameters {
+                &self.1
+            }
         }
 
         impl From<Property> for $name {


### PR DESCRIPTION
With this helper function, one can get the parameters from a helper data
type. For example the email data parameters "HOME", "WORK".