### PR TITLE
Update dependency: error-chain

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 keywords = ["vobject", "icalendar", "calendar", "contacts"]
 
 [dependencies]
-error-chain = "0.11"
+error-chain = "0.12"
 chrono      = { version = "0.4", optional = true }
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ readme = "README.md"
 keywords = ["vobject", "icalendar", "calendar", "contacts"]
 
 [dependencies]
-error-chain = "0.12"
 chrono      = { version = "0.4", optional = true }
+failure = "0.1"
 
 [features]
 default         = []

--- a/src/component.rs
+++ b/src/component.rs
@@ -3,11 +3,8 @@ use std::collections::BTreeMap;
 
 use property::Property;
 use parser::Parser;
-use failure::Fallible as Result;
-use failure::Error;
 
 use error::*;
-
 
 #[derive(Clone, Debug)]
 pub struct Component {
@@ -72,7 +69,7 @@ impl Component {
 }
 
 impl FromStr for Component {
-    type Err = Error;
+    type Err = VObjectErrorKind;
 
     /// Same as `vobject::parse_component`
     fn from_str(s: &str) -> Result<Component> {
@@ -85,8 +82,7 @@ pub fn parse_component(s: &str) -> Result<Component> {
     let (rv, new_s) = try!(read_component(s));
     if !new_s.is_empty() {
         let s = format!("Trailing data: `{}`", new_s);
-        let kind = VObjectErrorKind::ParserError(s);
-        return Err(Error::from(kind));
+        return Err(VObjectErrorKind::ParserError(s));
     }
 
     Ok(rv)

--- a/src/component.rs
+++ b/src/component.rs
@@ -3,7 +3,11 @@ use std::collections::BTreeMap;
 
 use property::Property;
 use parser::Parser;
+use failure::Fallible as Result;
+use failure::Error;
+
 use error::*;
+
 
 #[derive(Clone, Debug)]
 pub struct Component {
@@ -68,7 +72,7 @@ impl Component {
 }
 
 impl FromStr for Component {
-    type Err = VObjectError;
+    type Err = Error;
 
     /// Same as `vobject::parse_component`
     fn from_str(s: &str) -> Result<Component> {
@@ -82,7 +86,7 @@ pub fn parse_component(s: &str) -> Result<Component> {
     if !new_s.is_empty() {
         let s = format!("Trailing data: `{}`", new_s);
         let kind = VObjectErrorKind::ParserError(s);
-        return Err(VObjectError::from_kind(kind));
+        return Err(Error::from(kind));
     }
 
     Ok(rv)

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,30 +1,11 @@
+#[derive(Debug, Clone, Eq, PartialEq, Fail)]
+pub enum VObjectErrorKind {
+    #[fail(display = "Parser error: {}", _0)]
+    ParserError(String),
 
-error_chain! {
+    #[fail(display = "Not a Vcard")]
+    NotAVCard,
 
-    types {
-        VObjectError, VObjectErrorKind, ResultExt, Result;
-    }
-
-    foreign_links {
-        ChronoParseError(::chrono::format::ParseError) #[cfg(feature = "timeconversions")];
-    }
-
-    errors {
-        ParserError(desc: String) {
-            description("Parser error")
-            display("{}", desc)
-        }
-
-        NotAVCard {
-            description("Input is not a valid VCard")
-            display("Passed content string is not a VCard")
-        }
-
-        NotAnICalendar(content: String) {
-            description("Input is not a valid ICalendar")
-            display("Not an ICalendar: '{}'", content)
-        }
-    }
-
-
+    #[fail(display = "Not a Icalendar: {}", _0)]
+    NotAnICalendar(String),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,3 +9,5 @@ pub enum VObjectErrorKind {
     #[fail(display = "Not a Icalendar: {}", _0)]
     NotAnICalendar(String),
 }
+
+pub type Result<T> = ::std::result::Result<T, VObjectErrorKind>;

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,6 +8,9 @@ pub enum VObjectErrorKind {
 
     #[fail(display = "Not a Icalendar: {}", _0)]
     NotAnICalendar(String),
+
+    #[fail(display = "{}", _0)]
+    ChronoError(::chrono::format::ParseError),
 }
 
 pub type Result<T> = ::std::result::Result<T, VObjectErrorKind>;

--- a/src/icalendar.rs
+++ b/src/icalendar.rs
@@ -1,6 +1,9 @@
 use std::result::Result as RResult;
 use std::collections::BTreeMap;
 
+use failure::Error;
+use failure::Fallible as Result;
+
 use component::Component;
 use component::parse_component;
 use property::Property;
@@ -26,10 +29,7 @@ impl ICalendar {
     pub fn build(s: &str) -> Result<ICalendar> {
         let c = parse_component(s)?;
         Self::from_component(c)
-            .map_err(|_| {
-                let kind = VObjectErrorKind::NotAnICalendar(s.to_owned());
-                VObjectError::from_kind(kind)
-            })
+            .map_err(|_| Error::from(VObjectErrorKind::NotAnICalendar(s.to_owned())))
     }
 
     pub fn empty() -> ICalendar {
@@ -175,7 +175,7 @@ impl AsDateTime for Dtend {
             Ok(dt) => Ok(Time::DateTime(dt)),
             Err(_) => NaiveDate::parse_from_str(&self.0, DATE_FMT)
                 .map(Time::Date)
-                .map_err(From::from),
+                .map_err(Error::from),
         }
     }
 
@@ -189,7 +189,7 @@ impl AsDateTime for Dtstart {
             Ok(dt) => Ok(Time::DateTime(dt)),
             Err(_) => NaiveDate::parse_from_str(&self.0, DATE_FMT)
                 .map(Time::Date)
-                .map_err(From::from),
+                .map_err(Error::from),
         }
     }
 
@@ -203,7 +203,7 @@ impl AsDateTime for Dtstamp {
             Ok(dt) => Ok(Time::DateTime(dt)),
             Err(_) => NaiveDate::parse_from_str(&self.0, DATE_FMT)
                 .map(Time::Date)
-                .map_err(From::from),
+                .map_err(Error::from),
         }
     }
 

--- a/src/icalendar.rs
+++ b/src/icalendar.rs
@@ -171,7 +171,7 @@ impl AsDateTime for Dtend {
             Ok(dt) => Ok(Time::DateTime(dt)),
             Err(_) => NaiveDate::parse_from_str(&self.0, DATE_FMT)
                 .map(Time::Date)
-                .map_err(Error::from),
+                .map_err(VObjectErrorKind::ChronoError),
         }
     }
 
@@ -185,7 +185,7 @@ impl AsDateTime for Dtstart {
             Ok(dt) => Ok(Time::DateTime(dt)),
             Err(_) => NaiveDate::parse_from_str(&self.0, DATE_FMT)
                 .map(Time::Date)
-                .map_err(Error::from),
+                .map_err(VObjectErrorKind::ChronoError),
         }
     }
 
@@ -199,7 +199,7 @@ impl AsDateTime for Dtstamp {
             Ok(dt) => Ok(Time::DateTime(dt)),
             Err(_) => NaiveDate::parse_from_str(&self.0, DATE_FMT)
                 .map(Time::Date)
-                .map_err(Error::from),
+                .map_err(VObjectErrorKind::ChronoError),
         }
     }
 

--- a/src/icalendar.rs
+++ b/src/icalendar.rs
@@ -1,9 +1,6 @@
 use std::result::Result as RResult;
 use std::collections::BTreeMap;
 
-use failure::Error;
-use failure::Fallible as Result;
-
 use component::Component;
 use component::parse_component;
 use property::Property;
@@ -28,8 +25,7 @@ impl ICalendar {
     ///
     pub fn build(s: &str) -> Result<ICalendar> {
         let c = parse_component(s)?;
-        Self::from_component(c)
-            .map_err(|_| Error::from(VObjectErrorKind::NotAnICalendar(s.to_owned())))
+        Self::from_component(c).map_err(|_| VObjectErrorKind::NotAnICalendar(s.to_owned()))
     }
 
     pub fn empty() -> ICalendar {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #[macro_use]
-extern crate error_chain;
+extern crate failure;
 
 #[cfg(feature = "timeconversions")]
 extern crate chrono;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -362,6 +362,7 @@ mod tests {
         // Test for infinite loops as well
         use std::sync::mpsc::{channel, RecvTimeoutError};
         use std::time::Duration;
+        use error::VObjectErrorKind;
         let mut p = Parser {input: "BEGIN:a\nBEGIN:b\nEND:a", pos: 0};
 
         let (tx, rx) = channel();
@@ -369,7 +370,12 @@ mod tests {
 
         match rx.recv_timeout(Duration::from_millis(50)) {
             Err(RecvTimeoutError::Timeout) => assert!(false),
-            Ok(Err(VObjectError(VObjectErrorKind::ParserError{..}, _ ))) => assert!(true),
+            Ok(Err(e)) => {
+                match e.downcast_ref::<VObjectErrorKind>() {
+                    Some(VObjectErrorKind::ParserError { .. }) => assert!(true),
+                    _ => assert!(false),
+                }
+            },
             _ => assert!(false),
         }
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,5 +1,8 @@
 use std::collections::BTreeMap;
 
+use failure::Fallible as Result;
+use failure::Error;
+
 use component::Component;
 use property::Property;
 use error::*;
@@ -60,13 +63,13 @@ impl<'s> Parser<'s> {
             Some((x, _)) => x,
             None => {
                 let kind = VObjectErrorKind::ParserError(format!("Expected {}, found EOL", c));
-                return Err(VObjectError::from_kind(kind))
+                return Err(Error::from(kind))
            }
         };
 
         if real_c != c {
             let kind = VObjectErrorKind::ParserError(format!("Expected {}, found {}", c, real_c));
-            return Err(VObjectError::from_kind(kind))
+            return Err(Error::from(kind))
         };
 
         Ok(())
@@ -105,7 +108,7 @@ impl<'s> Parser<'s> {
         } else {
             self.pos = start_pos;
             let kind = VObjectErrorKind::ParserError("Expected EOL.".to_owned());
-            Err(VObjectError::from_kind(kind))
+            Err(Error::from(kind))
         }
     }
 
@@ -175,7 +178,7 @@ impl<'s> Parser<'s> {
         let rv = self.consume_while(|x| x == '-' || x.is_alphanumeric());
         if rv.is_empty() {
             let kind = VObjectErrorKind::ParserError("No property name found.".to_owned());
-            Err(VObjectError::from_kind(kind))
+            Err(Error::from(kind))
         } else {
             Ok(rv)
         }
@@ -211,7 +214,7 @@ impl<'s> Parser<'s> {
             Ok(x) => Ok(x),
             Err(e) => {
                 let kind = VObjectErrorKind::ParserError(format!("No param name found: {}", e));
-                Err(VObjectError::from_kind(kind))
+                Err(Error::from(kind))
             }
         }
     }
@@ -267,7 +270,7 @@ impl<'s> Parser<'s> {
         if property.name != "BEGIN" {
             self.pos = start_pos;
             let kind = VObjectErrorKind::ParserError("Expected BEGIN tag.".to_owned());
-            return Err(VObjectError::from_kind(kind));
+            return Err(Error::from(kind));
         };
 
         // Create a component with the name of the BEGIN tag's value
@@ -286,7 +289,7 @@ impl<'s> Parser<'s> {
                                     component.name,
                                     property.raw_value);
                     let kind = VObjectErrorKind::ParserError(s);
-                    return Err(VObjectError::from_kind(kind));
+                    return Err(Error::from(kind));
                 }
 
                 break;

--- a/src/vcard.rs
+++ b/src/vcard.rs
@@ -6,8 +6,6 @@ use component::parse_component;
 use property::Property;
 
 use std::result::Result as RResult;
-use failure::Fallible as Result;
-use failure::Error;
 use error::*;
 
 #[derive(Debug)]
@@ -27,7 +25,7 @@ impl Vcard {
     pub fn build(s: &str) -> Result<Vcard> {
         parse_component(s)
             .and_then(|c| {
-                Self::from_component(c).map_err(|_| Error::from(VObjectErrorKind::NotAVCard))
+                Self::from_component(c).map_err(|_| VObjectErrorKind::NotAVCard)
             })
     }
 

--- a/src/vcard.rs
+++ b/src/vcard.rs
@@ -6,6 +6,8 @@ use component::parse_component;
 use property::Property;
 
 use std::result::Result as RResult;
+use failure::Fallible as Result;
+use failure::Error;
 use error::*;
 
 #[derive(Debug)]
@@ -25,11 +27,7 @@ impl Vcard {
     pub fn build(s: &str) -> Result<Vcard> {
         parse_component(s)
             .and_then(|c| {
-                Self::from_component(c)
-                    .map_err(|_| {
-                        let kind = VObjectErrorKind::NotAVCard;
-                        VObjectError::from_kind(kind)
-                    })
+                Self::from_component(c).map_err(|_| Error::from(VObjectErrorKind::NotAVCard))
             })
     }
 


### PR DESCRIPTION
As this is a breaking change, we would need to release a new minor version of rust-vobject for this.