### PR TITLE
Fix: Add feature flag for error type

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -9,6 +9,7 @@ pub enum VObjectErrorKind {
     #[fail(display = "Not a Icalendar: {}", _0)]
     NotAnICalendar(String),
 
+    #[cfg(feature = "timeconversions")]
     #[fail(display = "{}", _0)]
     ChronoError(::chrono::format::ParseError),
 }


### PR DESCRIPTION
I noticed that master fails because I forgot to specify this.

CI did not fail because CI compiles with `--all-features`.