### PR TITLE
Use Property::new() in make_builder_fn!

### DIFF
--- a/src/vcard.rs
+++ b/src/vcard.rs
@@ -111,13 +111,7 @@ macro_rules! make_builder_fn {
                 .collect::<Vec<_>>()
                 .join(";");
 
-            let prop = Property {
-                name: String::from($property_name),
-                params: params,
-                raw_value: raw_value,
-                prop_group: None
-            };
-
+            let prop = Property::new($property_name, raw_value);
             self.properties.entry(String::from($property_name)).or_insert(vec![]).push(prop);
             self
         }
@@ -135,12 +129,7 @@ macro_rules! make_builder_fn {
                 .join(";");
 
 
-            let prop = Property {
-                name: String::from($property_name),
-                params: BTreeMap::new(),
-                raw_value: raw_value,
-                prop_group: None
-            };
+            let prop = Property::new($property_name, raw_value);
             self.properties.entry(String::from($property_name)).or_insert(vec![]).push(prop);
             self
         }


### PR DESCRIPTION
In the current VcardBuilder implementation, builder functions are created 
with the macro make_builder_fn!. This macro was instantiating Property
object directly, thus not using the Property::new() interface.

When using the Property::new(name, value) interface, the value is escaped
before being stored in the raw_value field. It was not the case when using 
direct instantiation.